### PR TITLE
Update obsolete reference to Ubuntu AppIndicator

### DIFF
--- a/docs/status-icons.md
+++ b/docs/status-icons.md
@@ -38,7 +38,7 @@ gnome-shell-extension-prefs
 ```
 
 …and press <kbd>Enter</kbd>. In the **Shell Extensions** window that comes up,
-turn on the **Ubuntu AppIndicators** switch.
+turn on the **KStatusNotifierItem/AppIndicator Support** switch.
 
 Lastly, you may need to **log out** and back in for icons to show up. When you
 do, any app's status icons will show up at the right-side of the top panel, next


### PR DESCRIPTION
Replaced with KStatusNotifierItem/AppIndicator Support switch as the Ubuntu AppIndicator is no longer visible.